### PR TITLE
优化TOKEN的类型判断方式

### DIFF
--- a/lib/parse-token.js
+++ b/lib/parse-token.js
@@ -16,19 +16,21 @@ function tokenFormat(token, index = 0) {
 }
 
 function parseToken(token) {
-  const likeArray = /^\[.*\]$/.test(token)
-  const likeObject = /^\{.*\}$/.test(token)
+  try {
+    token = JSON.parse(token)
+    console.log('传入的TOKEN变量是JSON对象')
+  } catch (e) {
+    console.log('传入的TOKEN变量是非JSON对象')
+  }
+  const likeArray = token.constructor == Array
+  const likeObject = token.constructor == Object
   let tokenList = []
 
   if (!likeArray && !likeObject) {
     return [tokenFormat(token)]
   }
 
-  try {
-    tokenList = tokenList.concat(JSON.parse(token))
-  } catch (e) {
-    throw new Error('JSON 格式有误' + e)
-  }
+  tokenList = tokenList.concat(token)
 
   return tokenList.map(tokenFormat)
 }


### PR DESCRIPTION
在secrets中传入格式化的JSON字符串，例如：
```json
{
    "token":"zzzzzz",
    "tgUid":"1111111"
}
```
代码中取到的值是`{\n"token": "zzzzzz",\n"tgUid": "1111111"\n}`，在JS里面过不了`^\{.*\}$`这个正则表达式的判断，会导致把整个JSON字符串当做token传入。