### PR TITLE
Update coupons.js

### DIFF
--- a/lib/coupons.js
+++ b/lib/coupons.js
@@ -44,7 +44,7 @@ async function getTemplateData() {
     `https://market.waimai.meituan.com/api/template/get?env=current&el_biz=waimai&el_page=gundam.loader&gundam_id=${GUNDAM_ID}`
   ).then((rep) => rep.text())
   const matchGlobal = text.match(/globalData: ({.+})/)
-  const matchAppJs = text.match(/https:\/\/[./_-\w]+app\.js(?=")/g)
+  const matchAppJs = text.match(/https:\/\/[./_-\w]+app\.js/g)
 
   try {
     const globalData = JSON.parse(matchGlobal[1])


### PR DESCRIPTION
美团更新了获取app.js的url，现在app.js的url后面不带参数了，导致正则表达式无法获取app.js的url，从而导致活动模板配置失败，代码失效。

将lib/coupons.js文件的第47行改为：

const matchAppJs = text.match(/https://[./_-\w]+app.js/g)

可解决问题。